### PR TITLE
fix(color): warning is now lightgreen

### DIFF
--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -34,7 +34,7 @@ $lang-select-active-bg: $examples-bg !default; // feel free to change this to bl
 $lang-select-pressed-bg: #111 !default; // color of language tab bg when mouse is pressed
 $main-bg: #f3f7f9 !default;
 $aside-notice-bg: #8fbcd4 !default;
-$aside-warning-bg: #c97a7e !default;
+$aside-warning-bg: #b5d8aa !default;
 $aside-success-bg: #f6007b !default;
 $search-notice-bg: #c97a7e !default;
 


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->